### PR TITLE
Removes all reqwest client global states

### DIFF
--- a/database_report_generator/src/currency_exchangerate.rs
+++ b/database_report_generator/src/currency_exchangerate.rs
@@ -1,10 +1,14 @@
-use crate::{errors::AppError, REQWEST_CLIENT};
+use crate::errors::AppError;
 use app_config::{secret_string::Secret, APP_CONFIG};
 use serde_json::Value;
 
 const EXCHANGERATE_URL: &str = "https://v6.exchangerate-api.com/v6/{API_KEY}/latest/{FROM}";
 
-pub async fn convert_currency<S1, S2>(from: S1, to: S2) -> Result<f64, AppError>
+pub async fn convert_currency<S1, S2>(
+  reqwest_client: reqwest::Client,
+  from: S1,
+  to: S2,
+) -> Result<f64, AppError>
 where
   S1: AsRef<str>,
   S2: AsRef<str>,
@@ -20,7 +24,7 @@ where
       Secret::read_secret_string(api_key.read_value()),
     )
     .replace("{FROM}", from);
-  let request_response = REQWEST_CLIENT.get(request_url).send().await?;
+  let request_response = reqwest_client.get(request_url).send().await?;
 
   if !request_response.status().is_success() {
     return Err(AppError::FailedToRetrieveCurrenyExchangeRates(

--- a/database_report_generator/src/lib.rs
+++ b/database_report_generator/src/lib.rs
@@ -18,10 +18,6 @@ pub mod upload_reports;
 /// Message containing this percentage of emotes per word is emote dominant.
 pub const EMOTE_DOMINANCE: f32 = 0.7;
 
-lazy_static::lazy_static! {
-  pub static ref REQWEST_CLIENT: reqwest::Client = reqwest::Client::new();
-}
-
 /// Generates reports for the given stream ID.
 /// Returns a list of the name and report string.
 pub async fn generate_reports(

--- a/database_report_generator/src/pastebin.rs
+++ b/database_report_generator/src/pastebin.rs
@@ -1,5 +1,4 @@
 use crate::errors::AppError;
-use crate::REQWEST_CLIENT;
 use app_config::secret_string::Secret;
 use app_config::APP_CONFIG;
 use std::collections::HashMap;
@@ -13,6 +12,7 @@ pub async fn generate_pastebin<S1: AsRef<str>, S2: AsRef<str>>(
   let Some(api_key) = APP_CONFIG.pastebin_api_key() else {
     return Err(AppError::MissingPastebinApiKey);
   };
+  let reqwest_client = reqwest::Client::new();
 
   let parameters = HashMap::from([
     (
@@ -24,7 +24,7 @@ pub async fn generate_pastebin<S1: AsRef<str>, S2: AsRef<str>>(
     ("api_paste_name", name.as_ref()),
   ]);
 
-  let response = REQWEST_CLIENT
+  let response = reqwest_client
     .post("https://pastebin.com/api/api_post.php")
     .form(&parameters)
     .send()

--- a/entity_extensions/src/lib.rs
+++ b/entity_extensions/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(async_fn_in_trait)]
 #![allow(clippy::needless_return)]
 
-use lazy_static::lazy_static;
-
 pub mod prelude;
 
 pub mod emote;
@@ -13,7 +11,3 @@ pub mod twitch_user_unknown_user_association;
 pub mod unknown_user;
 
 pub use anyhow::Error as ExtensionError;
-
-lazy_static! {
-  pub(crate) static ref REQWEST_CLIENT: reqwest::Client = reqwest::Client::new();
-}

--- a/entity_extensions/src/stream.rs
+++ b/entity_extensions/src/stream.rs
@@ -1,4 +1,3 @@
-use crate::REQWEST_CLIENT;
 use crate::stream_message::StreamMessageExtensions;
 use anyhow::anyhow;
 use app_config::APP_CONFIG;
@@ -200,6 +199,7 @@ where
   I: IntoIterator<Item = &'a twitch_user::Model>,
 {
   let mut query_url = Url::parse(HELIX_STREAM_QUERY_URL)?;
+  let reqwest_client = reqwest::Client::new();
 
   query_url.query_pairs_mut().append_pair("first", "100");
 
@@ -210,7 +210,7 @@ where
   }
 
   Ok(
-    REQWEST_CLIENT
+    reqwest_client
       .get(query_url)
       .header(
         "Authorization",

--- a/entity_extensions/src/twitch_user.rs
+++ b/entity_extensions/src/twitch_user.rs
@@ -1,4 +1,3 @@
-use crate::REQWEST_CLIENT;
 use crate::prelude::*;
 use anyhow::anyhow;
 use app_config::APP_CONFIG;
@@ -154,6 +153,7 @@ impl TwitchUserExtensions for twitch_user::Model {
     }
 
     let mut query_url = Url::parse(HELIX_USER_QUERY_URL)?;
+    let reqwest_client = reqwest::Client::new();
 
     {
       let mut query_pairs = query_url.query_pairs_mut();
@@ -170,7 +170,7 @@ impl TwitchUserExtensions for twitch_user::Model {
       }
     }
 
-    let request = REQWEST_CLIENT
+    let request = reqwest_client
       .get(query_url)
       .header(
         "Authorization",

--- a/src/channel/third_party_emote_list.rs
+++ b/src/channel/third_party_emote_list.rs
@@ -1,5 +1,4 @@
 use crate::errors::AppError;
-use crate::REQWEST_CLIENT;
 use entities::twitch_user;
 use serde_json::Value;
 use std::collections::HashSet;
@@ -56,8 +55,9 @@ impl EmoteList {
     let mut _7tv_query_url = Url::parse(_7TV_API_URL)?;
     _7tv_query_url = _7tv_query_url.join("emote-sets/global")?;
     // let _7tv = Self::_7tv_emote_list(client, _7tv_query_url).await?;
+    let reqwest_client = reqwest::Client::new();
 
-    let response = REQWEST_CLIENT.get(_7tv_query_url).send().await?;
+    let response = reqwest_client.get(_7tv_query_url).send().await?;
     let response_body = response.text().await?;
 
     if response_body.contains("error code: ") {
@@ -112,7 +112,8 @@ impl EmoteList {
 
   async fn _7tv_emote_list(query_url: Url) -> Result<HashSet<String>, AppError> {
     tracing::info!("querying emote set for url: {:?}", query_url);
-    let response = REQWEST_CLIENT.get(query_url).send().await?;
+    let reqwest_client = reqwest::Client::new();
+    let response = reqwest_client.get(query_url).send().await?;
     let response_body = response.text().await?;
 
     if response_body.contains("error code: ") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,6 @@
 #![allow(async_fn_in_trait)]
 
-use lazy_static::lazy_static;
-
 pub mod channel;
 pub mod errors;
 pub mod irc_chat;
 pub mod logging;
-
-lazy_static! {
-  pub static ref REQWEST_CLIENT: reqwest::Client = reqwest::Client::new();
-}


### PR DESCRIPTION
In order to potential leaks of secrets and clean some unnecessary global state, this commit removes all instances of global reqwest clients. Opting instead to create a new client every time it's needed.