### PR TITLE
Fixes searching users on message search

### DIFF
--- a/backend/src/routes/helpers/get_users.rs
+++ b/backend/src/routes/helpers/get_users.rs
@@ -49,4 +49,32 @@ pub trait GetUsers {
 
     Err(AppError::NoQueryParameterFound)
   }
+
+  fn get_missing_user_error(&self) -> AppError {
+    if let Some(user_login) = self.get_login() {
+      return AppError::CouldNotFindUserByLoginName {
+        login: user_login.to_string(),
+      };
+    }
+
+    if let Some(twitch_id) = self.get_twitch_id() {
+      return AppError::CouldNotFindUserByTwitchId {
+        user_id: twitch_id.to_string(),
+      };
+    }
+
+    if let Some(logins_string) = self.get_many_logins() {
+      return AppError::CouldNotFindUserByLoginName {
+        login: logins_string.to_string(),
+      };
+    }
+
+    if let Some(twitch_ids) = self.get_many_twitch_ids() {
+      return AppError::CouldNotFindUserByTwitchId {
+        user_id: twitch_ids.to_string(),
+      };
+    }
+
+    AppError::NoQueryParameterFound
+  }
 }

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=http://homelab:30020
+VITE_BACKEND_URL=http://127.0.0.1:8080


### PR DESCRIPTION
In order to fix the bug where you couldn't search by twitch-id or guess a user's login, this commit implements the `GetUsers` trait for UserMessagesQuery to properly fetch the user. In addition, to fix searching by user-id,