### PR TITLE
Rewrite chat ranking report and adds a column

### DIFF
--- a/report_generator/Cargo.toml
+++ b/report_generator/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0", features = ["derive"] }
 entities = { path = "../entities" }
 entity_extensions = { path = "../entity_extensions" }
 tokio = { version = "1.41", features = ["full"] }
-sea-orm = { version = "1.1.10", features = ["sqlx-mysql", "runtime-tokio", "macros"] } 
+sea-orm = { version = "1.1.10", features = ["sqlx-mysql", "runtime-tokio", "macros", "mock"] } 
 tabled = "0.20.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.*"

--- a/report_generator/src/lib.rs
+++ b/report_generator/src/lib.rs
@@ -1,6 +1,6 @@
+use crate::clap::Args;
 use crate::templates::chat_messages::get_messages_sent_ranking;
 use crate::templates::chat_statistics::get_chat_statistics_template;
-use crate::clap::Args;
 use conditions::query_conditions::AppQueryConditions;
 use errors::AppError;
 use templates::donation_rankings::get_donation_rankings_for_streamer_and_date;

--- a/report_generator/src/templates/chat_messages.rs
+++ b/report_generator/src/templates/chat_messages.rs
@@ -3,28 +3,24 @@ use crate::errors::AppError;
 use crate::EMOTE_DOMINANCE;
 use database_connection::get_database_connection;
 use entities::{emote_usage, stream_message, twitch_user};
+use messages_with_word_counts::{MessageWithWordCount, UserMessages};
 use num_traits::cast::ToPrimitive;
+use ranking_table::*;
 use sea_orm::entity::prelude::Decimal;
 use sea_orm::*;
 use std::collections::HashMap;
 use tabled::settings::Style;
-use tabled::{Table, Tabled};
+use tabled::Table;
 use tracing::instrument;
+
+mod messages_with_word_counts;
+mod ranking_table;
 
 const EMOTE_DOMINANCE_INFO: &str = "This table has omitted messages where more than {emote_message_threshold}% of the words were Twitch or third party emotes.";
 const USER_TAG_INFO: &str = r#"After a user's ranking will be indicators for both if they're subscribed and if they're a first time chatter.
 * for first time chatter.
 - for if the user isn't subscribed.
 "#;
-
-#[derive(Tabled)]
-struct RankingEntry {
-  place: String,
-  name: String,
-  messages_sent: usize,
-  chat_percentage: String,
-  avg_words_per_message: String,
-}
 
 /// Returns the (Leaderboard, Non-emote_dominant_leaderboard) for a given stream.
 ///
@@ -40,16 +36,11 @@ pub async fn get_messages_sent_ranking(
     .all(database_connection)
     .await?;
   let messages: Vec<&stream_message::Model> = messages.iter().collect();
-  tracing::info!("Getting emote filtered messages.");
-  let emote_filtered_messages =
-    emote_filtered_messages(messages.clone(), database_connection).await?;
-  tracing::info!("Got emote filtered messages.");
 
-  let unfiltered_rankings = get_rankings(messages).await?;
-  let emote_filtered_rankings = get_rankings(emote_filtered_messages).await?;
+  let rankings = calculate_rankings(messages, database_connection).await?;
 
-  let mut unfiltered_table = Table::new(unfiltered_rankings);
-  let mut filtered_table = Table::new(emote_filtered_rankings);
+  let mut unfiltered_table = Table::new(rankings.all_messages);
+  let mut filtered_table = Table::new(rankings.emote_filtered_messages);
 
   unfiltered_table.with(Style::markdown());
   filtered_table.with(Style::markdown());
@@ -68,134 +59,204 @@ pub async fn get_messages_sent_ranking(
   Ok((unfiltered_table, filtered_table))
 }
 
-async fn get_rankings(
+async fn calculate_rankings(
   messages: Vec<&stream_message::Model>,
-) -> Result<Vec<RankingEntry>, AppError> {
-  let database_connection = get_database_connection().await;
-  let mut chats_sent: HashMap<i32, usize> = HashMap::new();
-
-  for message in messages.iter() {
-    let entry = chats_sent.entry(message.twitch_user_id).or_default();
-    *entry += 1;
-  }
-
+  database_connection: &DatabaseConnection,
+) -> Result<ChatRankings, AppError> {
+  let mut chats_sent: HashMap<i32, UserMessages> = HashMap::new();
   let total_messages_sent = messages.len();
-  let mut chats_sent: Vec<(i32, usize)> = chats_sent.into_iter().collect();
-  chats_sent.sort_by_key(|(_, chats_sent)| *chats_sent);
-  chats_sent.reverse();
-  let mut rankings = vec![];
+  let mut emote_filtered_messages_sent: usize = 0;
+  let mut total_word_count: usize = 0;
+  let mut total_emote_filtered_chats_word_count: usize = 0;
 
-  for (place, (user_id, messages_sent)) in chats_sent.into_iter().enumerate() {
-    let place = place + 1;
-    let get_twitch_user_result = twitch_user::Entity::find_by_id(user_id)
-      .one(database_connection)
-      .await;
-    let twitch_user_login_name = match get_twitch_user_result {
-      Ok(Some(twitch_user)) => twitch_user.login_name.to_owned(),
-      Ok(None) => {
-        tracing::error!("Message found from a missing user. User ID: {}", user_id);
+  for message in messages {
+    let user_messages = chats_sent.entry(message.twitch_user_id).or_default();
 
-        String::from("UnknownUser")
-      }
-      Err(error) => {
-        tracing::error!(
-          "Failed to retrieve a user from the database. User ID: {}. Reason: {:?}",
-          user_id,
-          error
-        );
-        continue;
-      }
+    let (word_count, is_emote_dominant_message) =
+      match is_emote_message(message, database_connection).await {
+        Ok(Some(results)) => results,
+        Ok(None) => continue,
+        Err(error) => {
+          tracing::error!(
+            "Failed to determine if message `{}` is emote dominant. Reason: `{error}`",
+            message.id
+          );
+          continue;
+        }
+      };
+
+    let message = MessageWithWordCount {
+      stream_message: message,
+      word_count,
+      is_emote_dominant: is_emote_dominant_message,
     };
 
-    let user_messages: Vec<&&stream_message::Model> = messages
-      .iter()
-      .filter(|message| message.twitch_user_id == user_id)
-      .collect();
+    total_word_count += word_count;
 
-    let user_is_subscribed = user_messages
-      .iter()
-      .any(|user_message| user_message.is_subscriber == 1);
-    let first_message_sent_this_stream = user_messages
-      .iter()
-      .any(|user_message| user_message.is_first_message == 1);
-    let avg_words_per_message = user_messages
-      .iter()
-      .filter_map(|message| Some(message.contents.as_ref()?.split(' ').count()))
-      .sum::<usize>() as f32
-      / user_messages.len() as f32;
+    if is_emote_dominant_message {
+      total_emote_filtered_chats_word_count += word_count;
+      emote_filtered_messages_sent += 1;
+    }
 
-    let mut place = place.to_string();
+    user_messages.insert_message(message);
+  }
 
-    if first_message_sent_this_stream {
+  let mut chats_sent = replace_ids_with_users(chats_sent, database_connection).await?;
+
+  chats_sent.sort_by(|(_, lhs), (_, rhs)| rhs.all_messages.len().cmp(&lhs.all_messages.len()));
+
+  let unfiltered_message_rankings: Vec<RankingEntry> = chats_sent
+    .iter()
+    .enumerate()
+    .map(|(place, (user, user_messages))| {
+      let mut place = (place + 1).to_string();
+      let messages_sent = user_messages.all_messages.len();
+      let chat_percentage = messages_sent as f32 / total_messages_sent as f32 * 100.0;
+      let average_words_per_message = user_messages.total_words_sent as f32 / messages_sent as f32;
+      let percentage_of_all_words = user_messages.total_words_sent as f32 / total_word_count as f32 * 100.0;
+
+      // Sanity check just in case ids do not match
+      let id_from_user = user.id;
+      let id_from_message = user_messages.all_messages[0].stream_message.twitch_user_id;
+      assert_eq!(
+        id_from_user,
+        id_from_message,
+        "Mismatch in user ids detected when processing message rankings. {id_from_user} != {id_from_message}"
+      );
+
+    if user_messages.first_message_sent_this_stream {
       place.push('*')
     }
-    if !user_is_subscribed {
+    if !user_messages.user_is_subscribed {
       place.push('-')
     }
 
-    let chat_percentage = messages_sent as f32 / total_messages_sent as f32 * 100.0;
+      RankingEntry {
+        place,
+        name: user.login_name.clone(),
+        messages_sent,
+        chat_percentage: format!("{:.4}", chat_percentage),
+        avg_words_per_message: format!("{:.2}", average_words_per_message),
+        percentage_of_all_words: format!("{:.2}", percentage_of_all_words), 
+      }
+    })
+    .collect();
 
-    let ranking = RankingEntry {
-      place,
-      name: twitch_user_login_name,
-      messages_sent,
-      chat_percentage: format!("{:.4}", chat_percentage),
-      avg_words_per_message: format!("{:.2}", avg_words_per_message),
-    };
+  chats_sent.retain(|(_user, chats_sent)| !chats_sent.emote_filtered_messages.is_empty());
+  chats_sent.sort_by(|(_, lhs), (_, rhs)| {
+    rhs
+      .emote_filtered_messages
+      .len()
+      .cmp(&lhs.emote_filtered_messages.len())
+  });
 
-    rankings.push(ranking);
-  }
+  let emote_filtered_message_rankings: Vec<RankingEntry> = chats_sent
+    .iter()
+    .enumerate()
+    .map(|(place, (user, user_messages))| {
+      let mut place = (place + 1).to_string();
+      let messages_sent = user_messages.emote_filtered_messages.len();
+      let chat_percentage = messages_sent as f32 / emote_filtered_messages_sent as f32 * 100.0;
+      let average_words_per_message =
+        user_messages.total_words_sent_emote_filtered_messages as f32 / messages_sent as f32;
+      let percentage_of_all_words = user_messages.total_words_sent_emote_filtered_messages as f32
+        / total_emote_filtered_chats_word_count as f32
+        * 100.0;
 
-  Ok(rankings)
+      if user_messages.first_message_sent_this_stream {
+        place.push('*')
+      }
+      if !user_messages.user_is_subscribed {
+        place.push('-')
+      }
+
+      RankingEntry {
+        place,
+        name: user.login_name.clone(),
+        messages_sent,
+        chat_percentage: format!("{:.4}", chat_percentage),
+        avg_words_per_message: format!("{:.2}", average_words_per_message),
+        percentage_of_all_words: format!("{:.2}", percentage_of_all_words),
+      }
+    })
+    .collect();
+
+  Ok(ChatRankings {
+    all_messages: unfiltered_message_rankings,
+    emote_filtered_messages: emote_filtered_message_rankings,
+  })
 }
 
-async fn emote_filtered_messages<'a>(
-  messages: Vec<&'a stream_message::Model>,
+// Returns the real word count of the message and a bool if the message is emote dominant or not.
+// "Real word count" excludes the count of emotes used.
+//
+// Otherwise None is returned
+async fn is_emote_message(
+  message: &stream_message::Model,
   database_connection: &DatabaseConnection,
-) -> Result<Vec<&'a stream_message::Model>, AppError> {
-  let mut end_list: HashMap<i32, &stream_message::Model> = HashMap::default();
-
-  for message in messages {
-    if end_list.contains_key(&message.id) {
-      continue;
-    }
-
-    let Some(contents) = &message.contents else {
-      tracing::error!(
-        "Failed to get message with null contents. Message ID: {}",
-        message.id
-      );
-      continue;
-    };
-    let word_count = contents
-      .split_whitespace()
-      .filter(|word| !word.is_empty())
-      .count() as f32;
-
-    let sum_usage_query = format!(
-      "SELECT COALESCE(SUM({}), 0) AS total FROM {} WHERE {} = {}",
-      emote_usage::Column::UsageCount.to_string(),
-      emote_usage::Entity.to_string(),
-      emote_usage::Column::StreamMessageId.to_string(),
+) -> Result<Option<(usize, bool)>, AppError> {
+  let Some(contents) = &message.contents else {
+    tracing::error!(
+      "Failed to get message with null contents. Message ID: {}",
       message.id
     );
-    let sum_usage_statement = Statement::from_string(DatabaseBackend::MySql, sum_usage_query);
-    let Some(query_result) = database_connection.query_one(sum_usage_statement).await? else {
-      tracing::warn!("Skipping result for message {} at step 1", message.id);
-      continue;
-    };
-    let total_emotes_used: Decimal = query_result.try_get("", "total")?;
-    let Some(total_emotes_used) = total_emotes_used.to_f32() else {
-      tracing::warn!("Skipping result for message {} at step 2", message.id);
-      continue;
-    };
 
-    if total_emotes_used / word_count <= EMOTE_DOMINANCE {
-      end_list.insert(message.id, message);
-    }
-  }
+    return Ok(None);
+  };
+  let word_count = contents
+    .split_whitespace()
+    .filter(|word| !word.is_empty())
+    .count() as f32;
 
-  Ok(end_list.into_values().collect())
+  let sum_usage_query = format!(
+    "SELECT COALESCE(SUM({}), 0) AS total FROM {} WHERE {} = {}",
+    emote_usage::Column::UsageCount.to_string(),
+    emote_usage::Entity.to_string(),
+    emote_usage::Column::StreamMessageId.to_string(),
+    message.id
+  );
+  let sum_usage_statement = Statement::from_string(DatabaseBackend::MySql, sum_usage_query);
+  let Some(query_result) = database_connection.query_one(sum_usage_statement).await? else {
+    tracing::warn!("Skipping result for message {} at step 1", message.id);
+    return Ok(None);
+  };
+  let total_emotes_used: Decimal = query_result.try_get("", "total")?;
+  let Some(total_emotes_used) = total_emotes_used.to_f32() else {
+    tracing::warn!("Skipping result for message {} at step 2", message.id);
+    return Ok(None);
+  };
+
+  let real_word_count = (word_count - total_emotes_used) as usize;
+  let is_emote_dominant_message = total_emotes_used / word_count <= EMOTE_DOMINANCE;
+
+  Ok(Some((real_word_count, is_emote_dominant_message)))
+}
+
+async fn replace_ids_with_users<'a>(
+  mut messages: HashMap<i32, UserMessages<'a>>,
+  database_connection: &DatabaseConnection,
+) -> Result<Vec<(twitch_user::Model, UserMessages<'a>)>, AppError> {
+  let user_ids: Vec<i32> = messages.keys().copied().collect();
+
+  let users = twitch_user::Entity::find()
+    .filter(twitch_user::Column::Id.is_in(user_ids))
+    .all(database_connection)
+    .await?;
+
+  Ok(
+    users
+      .into_iter()
+      .filter_map(|user| {
+        let Some(user_messages) = messages.remove(&user.id) else {
+          tracing::error!("Failed to find user `{}` from message list.", user.id);
+
+          return None;
+        };
+
+        Some((user, user_messages))
+      })
+      .collect(),
+  )
 }
 
 #[cfg(test)]
@@ -206,34 +267,128 @@ mod tests {
   use std::collections::BTreeMap;
 
   #[tokio::test]
-  async fn emote_filtered_messages_gives_expected_result() {
+  async fn calculate_rankings_gives_expected_result() {
+    let expected_user_query = vec![
+      twitch_user::Model {
+        id: 1,
+        twitch_id: 1,
+        login_name: "user1".into(),
+        display_name: "user1".into(),
+      },
+      twitch_user::Model {
+        id: 2,
+        twitch_id: 2,
+        login_name: "user2".into(),
+        display_name: "user2".into(),
+      },
+      twitch_user::Model {
+        id: 3,
+        twitch_id: 3,
+        login_name: "user3".into(),
+        display_name: "user3".into(),
+      },
+    ];
     let mock_database = MockDatabase::new(DatabaseBackend::MySql)
       .append_query_results([
-        vec![generate_total_query_result(3)],
-        vec![generate_total_query_result(7)],
+        vec![generate_total_query_result(0)],
+        vec![generate_total_query_result(2)],
+        vec![generate_total_query_result(2)],
+        vec![generate_total_query_result(0)],
+        vec![generate_total_query_result(2)],
+        vec![generate_total_query_result(2)],
         vec![generate_total_query_result(2)],
         vec![generate_total_query_result(0)],
       ])
+      .append_query_results([expected_user_query])
       .into_connection();
-    let expected_message_ids = [2, 3, 4];
-    let messages = vec![
-      generate_message(1, 2, "emote1, emote2, emote3"), //                 100% emotes
-      generate_message(2, 2, "e1, e2, e3, e4, e5, e6, e7, w1, w2, w3"), // 70% emotes
-      generate_message(3, 2, "emote1, emote2, word1, word2"), //           50% emotes
-      generate_message(4, 2, "word1, word2"),           //                 0% emotes
+    let messages = get_fake_stream_chat_logs();
+    let messages = messages.iter().collect();
+
+    let expected_chat_rankings = get_expected_chat_rankings();
+
+    let chat_rankings = calculate_rankings(messages, &mock_database).await.unwrap();
+
+    assert_eq!(chat_rankings, expected_chat_rankings);
+  }
+
+  /// Based on messages from `get_fake_stream_chat_logs`
+  fn get_expected_chat_rankings() -> ChatRankings {
+    let unfiltered_rankings = vec![
+      RankingEntry {
+        place: "1".into(),
+        name: "user1".into(),
+        messages_sent: 3,
+        chat_percentage: format!("{:.4}", 3.0 / 8.0 * 100.0),
+        avg_words_per_message: format!("{:.2}", 6.0 / 3.0),
+        percentage_of_all_words: format!("{:.2}", 6.0 / 11.0 * 100.0),
+      },
+      RankingEntry {
+        place: "2".into(),
+        name: "user2".into(),
+        messages_sent: 3,
+        chat_percentage: format!("{:.4}", 3.0 / 8.0 * 100.0),
+        avg_words_per_message: format!("{:.2}", 2.0 / 3.0),
+        percentage_of_all_words: format!("{:.2}", 2.0 / 11.0 * 100.0),
+      },
+      RankingEntry {
+        place: "3*-".into(),
+        name: "user3".into(),
+        messages_sent: 2,
+        chat_percentage: format!("{:.4}", 2.0 / 8.0 * 100.0),
+        avg_words_per_message: format!("{:.2}", 3.0 / 2.0),
+        percentage_of_all_words: format!("{:.2}", 3.0 / 11.0 * 100.0),
+      },
+    ];
+    let emote_filtered_rankings = vec![
+      RankingEntry {
+        place: "1".into(),
+        name: "user1".into(),
+        messages_sent: 2,
+        chat_percentage: format!("{:.4}", 2.0 / 5.0 * 100.0),
+        avg_words_per_message: format!("{:.2}", 6.0 / 2.0),
+        percentage_of_all_words: format!("{:.2}", 6.0 / 11.0 * 100.0),
+      },
+      RankingEntry {
+        place: "2".into(),
+        name: "user2".into(),
+        messages_sent: 2,
+        chat_percentage: format!("{:.4}", 2.0 / 5.0 * 100.0),
+        avg_words_per_message: format!("{:.2}", 1.0),
+        percentage_of_all_words: format!("{:.2}", 2.0 / 11.0 * 100.0),
+      },
+      RankingEntry {
+        place: "3*-".into(),
+        name: "user3".into(),
+        messages_sent: 1,
+        chat_percentage: format!("{:.4}", 1.0 / 5.0 * 100.0),
+        avg_words_per_message: format!("{:.2}", 3.0 / 1.0),
+        percentage_of_all_words: format!("{:.2}", 3.0 / 11.0 * 100.0),
+      },
     ];
 
-    let filtered_messages = emote_filtered_messages(messages.iter().collect(), &mock_database)
-      .await
-      .unwrap();
+    ChatRankings {
+      all_messages: unfiltered_rankings,
+      emote_filtered_messages: emote_filtered_rankings,
+    }
+  }
 
-    let mut sorted_message_ids: Vec<i32> = filtered_messages
-      .into_iter()
-      .map(|message| message.id)
-      .collect();
-    sorted_message_ids.sort();
+  fn get_fake_stream_chat_logs() -> Vec<stream_message::Model> {
+    let mut first_time_message_not_subbed = generate_message(7, 3, "emote emote");
+    first_time_message_not_subbed.is_first_message = 1;
+    first_time_message_not_subbed.is_subscriber = 0;
+    let mut second_message_not_subbed = generate_message(8, 3, "word in message");
+    second_message_not_subbed.is_subscriber = 0;
 
-    assert_eq!(sorted_message_ids, expected_message_ids);
+    vec![
+      generate_message(1, 1, "This is message"),
+      generate_message(2, 1, "emote emote This is message"),
+      generate_message(3, 1, "emote emote"),
+      generate_message(4, 2, "message"),
+      generate_message(5, 2, "emote emote message"),
+      generate_message(6, 2, "emote emote"),
+      first_time_message_not_subbed,
+      second_message_not_subbed,
+    ]
   }
 
   fn generate_total_query_result(amount: i32) -> BTreeMap<&'static str, sea_orm::Value> {

--- a/report_generator/src/templates/chat_messages/messages_with_word_counts.rs
+++ b/report_generator/src/templates/chat_messages/messages_with_word_counts.rs
@@ -1,0 +1,42 @@
+use entities::*;
+
+#[derive(Debug, Default)]
+pub struct UserMessages<'a> {
+  pub all_messages: Vec<MessageWithWordCount<'a>>,
+  pub emote_filtered_messages: Vec<MessageWithWordCount<'a>>,
+
+  pub user_is_subscribed: bool,
+  pub first_message_sent_this_stream: bool,
+  pub total_words_sent: usize,
+  pub total_words_sent_emote_filtered_messages: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageWithWordCount<'a> {
+  pub stream_message: &'a stream_message::Model,
+  pub word_count: usize,
+
+  pub is_emote_dominant: bool,
+}
+
+impl<'a> UserMessages<'a> {
+  /// Inserts the given message and updates all values based on the message.
+  pub fn insert_message(&mut self, message: MessageWithWordCount<'a>) {
+    self.total_words_sent += message.word_count;
+
+    if message.stream_message.is_subscriber == 1 && !self.user_is_subscribed {
+      self.user_is_subscribed = message.stream_message.is_subscriber == 1;
+    }
+    if message.stream_message.is_first_message == 1 {
+      self.first_message_sent_this_stream = message.stream_message.is_first_message == 1
+    }
+
+    self.all_messages.push(message.clone());
+
+    if message.is_emote_dominant {
+      self.total_words_sent_emote_filtered_messages += message.word_count;
+
+      self.emote_filtered_messages.push(message)
+    }
+  }
+}

--- a/report_generator/src/templates/chat_messages/ranking_table.rs
+++ b/report_generator/src/templates/chat_messages/ranking_table.rs
@@ -1,0 +1,18 @@
+use tabled::Tabled;
+
+#[derive(Tabled, Debug, PartialEq, Eq)]
+pub struct RankingEntry {
+  pub place: String,
+  pub name: String,
+  pub messages_sent: usize,
+  pub chat_percentage: String,
+  pub avg_words_per_message: String,
+  #[tabled(rename = "%_of_all_words")]
+  pub percentage_of_all_words: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ChatRankings {
+  pub all_messages: Vec<RankingEntry>,
+  pub emote_filtered_messages: Vec<RankingEntry>,
+}

--- a/report_generator/src/templates/chat_statistics.rs
+++ b/report_generator/src/templates/chat_statistics.rs
@@ -42,7 +42,8 @@ pub async fn get_chat_statistics_template(
   let chat_statistics = ChatStatistics::new(query_conditions).await?;
   let (mut user_bans, user_timeouts) = get_timeouts(query_conditions, database_connection).await?;
   let raids = get_raids(query_conditions, database_connection).await?;
-  let top_emotes = get_top_n_emotes(query_conditions, database_connection, Some(TOP_N_EMOTES)).await?;
+  let top_emotes =
+    get_top_n_emotes(query_conditions, database_connection, Some(TOP_N_EMOTES)).await?;
   let mut statistics_template = String::from(STATS_FILE_TEMPLATE);
   let mut statistics_string = String::new();
 


### PR DESCRIPTION
In order to improve the speed and clarity of the chat ranking report code, this commit rewrites it to be more expandable and readable for future additions or edits.

In addition, this commit adds an additional column `%_of_all_words` which shows how much of all words sent that stream were from the given user on that row.