### PR TITLE
Fix empty message list from backend

### DIFF
--- a/backend/src/data_transfer_objects/stream_message.rs
+++ b/backend/src/data_transfer_objects/stream_message.rs
@@ -3,7 +3,7 @@ use entities::*;
 use entity_extensions::external_service::*;
 use sea_orm::{DatabaseConnection, LoaderTrait, prelude::DateTimeUtc};
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct StreamMessageUser {
   pub twitch_id: i32,
   pub login_name: String,
@@ -38,7 +38,7 @@ impl StreamMessageDto {
     database_connection: &DatabaseConnection,
     skip_emotes: bool,
   ) -> Result<Vec<Self>, AppError> {
-    let no_paired_users = vec![];
+    let no_paired_users = vec![None; user_messages.len()];
 
     Self::convert_messages_inner(
       user_messages,

--- a/backend/src/routes/users/messages.rs
+++ b/backend/src/routes/users/messages.rs
@@ -58,8 +58,13 @@ pub async fn get_messages(
     user_messages_query.paginate(database_connection, pagination.page_size);
   let user_messages = paginated_user_messages.fetch_page(pagination.page).await?;
 
+  let user_message_count = user_messages.len();
   let user_messages_dtos =
     StreamMessageDto::convert_messages(user_messages, database_connection, false).await?;
+
+  if user_message_count != user_messages_dtos.len() {
+    tracing::warn!("Mismatch in user message count after DTO conversion.");
+  }
 
   let ItemsAndPagesNumber {
     number_of_items,


### PR DESCRIPTION
In order to fix the back-end sending an empty list of messages, this commit actually populates the list of empty users being passed into the inner user message DTO conversion method. Previously the list was empty and getting zipped into the iterator, causing all messages to get dropped.